### PR TITLE
[RSDK-8438] add updating mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following attributes are available for `viam:cloudslam-wrapper:cloudslam`
 | `organization_id` | string | **Required**     | id string for your [organization](https://docs.viam.com/cloud/organizations/)        |
 | `location_id` | string | **Required**     | id string for your [location](https://docs.viam.com/cloud/locations/)        |
 | `machine_id` | string | **Required**     | id string for your [machine](https://docs.viam.com/appendix/apis/fleet/#find-machine-id)        |
-| `machine_part_id` | string | Optional     | optional id string for the [machine part](https://docs.viam.com/appendix/apis/fleet/#find-machine-id). only used when using local package creation        |
+| `machine_part_id` | string | Optional     | optional id string for the [machine part](https://docs.viam.com/appendix/apis/fleet/#find-machine-id). Used for local package creation and updating mode       |
 | `viam_version` | string | Optional     | optional string to identify which version of viam-server to use with cloudslam. Defaults to `stable`        |
 | `slam_version` | string | Optional     | optional string to identify which version of cartographer to use with cloudslam. Defaults to `stable`         |
 | `camera_freq_hz` | float | Optional     | set the expected capture frequency for your camera/lidar components. Defaults to `5`        |
@@ -63,3 +63,5 @@ To interact with a cloudslam mapping session, go to the `DoCommand` on the [Cont
 - {`"start": "<MAP_NAME>"`} will start a cloudslam mapping session using the configured SLAM service. If the request is successful the current map will appear in the cloudslam-wrapper's service card after ~1 minute
 - {`"stop": ""`} will stop an active cloudslam mapping session if one is running. The completed map can be found on the SLAM library tab of the machines page
 - {`"save-local-map": "<MAP_NAME>"`} will grab the current map from the configured SLAM service and upload it to your location, in the SLAM library tab of the machines page
+
+For updating a map using cloudslam, a `machine_part_id` must be configured. When configured, the module will check the machine's config to see if any slam maps are configured on the robot. If a slam map is found, cloudslam will be configured for updating mode and the map name will be inherited from the configured map.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ On the new service panel, copy and paste the following attribute template into y
 }
 ```
 
+In addition, in your Cartographer config the setting `"use_cloud_slam"` must be set to `true`. This only applies when trying to use cloudslam. Uploading a locally built map does not require this setting.
+
 ### Attributes
 
 The following attributes are available for `viam:cloudslam-wrapper:cloudslam`

--- a/cloudslam/app.go
+++ b/cloudslam/app.go
@@ -64,8 +64,8 @@ func CreateCloudSLAMClient(ctx context.Context, apiKey, apiKeyID, baseURL string
 	}, nil
 }
 
-// GetPackagesOnRobot makes a Config request to app and returns the first SLAM map that it finds on the robot.
-func (app *AppClient) GetPackagesOnRobot(ctx context.Context, partID string) (string, string, error) {
+// GetSLAMMapPackageOnRobot makes a Config request to app and returns the first SLAM map that it finds on the robot.
+func (app *AppClient) GetSLAMMapPackageOnRobot(ctx context.Context, partID string) (string, string, error) {
 	req := pbApp.ConfigRequest{Id: partID}
 	resp, err := app.RobotClient.Config(ctx, &req)
 	if err != nil {

--- a/cloudslam/app.go
+++ b/cloudslam/app.go
@@ -10,6 +10,7 @@ import (
 	pbCloudSLAM "go.viam.com/api/app/cloudslam/v1"
 	pbDataSync "go.viam.com/api/app/datasync/v1"
 	pbPackage "go.viam.com/api/app/packages/v1"
+	pbApp "go.viam.com/api/app/v1"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/utils/rpc"
 )
@@ -24,6 +25,7 @@ type AppClient struct {
 	CSClient      pbCloudSLAM.CloudSLAMServiceClient
 	PackageClient pbPackage.PackageServiceClient
 	SyncClient    pbDataSync.DataSyncServiceClient
+	RobotClient   pbApp.RobotServiceClient
 	HTTPClient    *http.Client // used for downloading pcds of the current cloudslam session
 }
 
@@ -53,12 +55,29 @@ func CreateCloudSLAMClient(ctx context.Context, apiKey, apiKeyID, baseURL string
 		CSClient:      pbCloudSLAM.NewCloudSLAMServiceClient(conn),
 		SyncClient:    pbDataSync.NewDataSyncServiceClient(conn),
 		PackageClient: pbPackage.NewPackageServiceClient(conn),
+		RobotClient:   pbApp.NewRobotServiceClient(conn),
 		// Disable keepalives makes each request only last for a single http GET request.
 		//  Doing this to prevent any active connections from causing goleaks when the viam-server shuts down.
 		// This might be redundant with CloseIdleConnections in Close(),
 		// and unsure if the extra cost of redoing the TLS handshake makes this change worth it
 		HTTPClient: &http.Client{Transport: &http.Transport{DisableKeepAlives: true}},
 	}, nil
+}
+
+// GetPackagesOnRobot makes a Config request to app and returns the first SLAM map that it finds on the robot.
+func (app *AppClient) GetPackagesOnRobot(ctx context.Context, partID string) (string, string, error) {
+	req := pbApp.ConfigRequest{Id: partID}
+	resp, err := app.RobotClient.Config(ctx, &req)
+	if err != nil {
+		return "", "", err
+	}
+	packages := resp.GetConfig().GetPackages()
+	for _, robotPackage := range packages {
+		if robotPackage.GetType() == "slam_map" {
+			return robotPackage.GetName(), robotPackage.GetVersion(), nil
+		}
+	}
+	return "", "", nil
 }
 
 // GetDataFromHTTP makes a request to an http endpoint app serves, which gets redirected to GCS.

--- a/cloudslam/cloudslam.go
+++ b/cloudslam/cloudslam.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"embed"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -25,6 +26,7 @@ import (
 
 const (
 	startJobKey               = "start"
+	updatingModeKey           = "updating mode"
 	stopJobKey                = "stop"
 	localPackageKey           = "save-local-map"
 	timeFormat                = time.RFC3339
@@ -68,6 +70,7 @@ type cloudslamWrapper struct {
 	activeJob         atomic.Pointer[string]
 	lastPose          atomic.Pointer[spatialmath.Pose]
 	lastPointCloudURL atomic.Pointer[string]
+	defaultpcd        []byte
 
 	slamService slam.Service           // the slam service that cloudslam will wrap
 	sensors     []*cloudslamSensorInfo // sensors currently in use by the slam service
@@ -79,7 +82,10 @@ type cloudslamWrapper struct {
 	organizationID string
 	viamVersion    string // optional cloudslam setting, describes which viam-server appimage to use(stable/latest/pr/pinned)
 	slamVersion    string // optional cloudslam setting, describes which cartographer appimage to use(stable/latest/pr/pinned)
-	defaultpcd     []byte
+
+	// updating mode values. A user can only use updating mode if the partID is configured
+	updatingMapName    string // empty if slam is not in updating mode
+	updatingMapVersion string // empty if slam is not in updating mode
 
 	// app clients for talking to app
 	app *AppClient
@@ -116,7 +122,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 		return []string{}, resource.NewConfigValidationFieldRequiredError(path, "api_key_id")
 	}
 	if cfg.RobotID == "" {
-		return []string{}, resource.NewConfigValidationFieldRequiredError(path, "robot_id")
+		return []string{}, resource.NewConfigValidationFieldRequiredError(path, "machine_id")
 	}
 	if cfg.LocationID == "" {
 		return []string{}, resource.NewConfigValidationFieldRequiredError(path, "location_id")
@@ -188,28 +194,46 @@ func newSLAM(
 		sensors:        csSensors,
 		app:            appClients,
 	}
-	wrapper.lastPose.Store(&initPose)
+
+	err = wrapper.initialize()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	return wrapper, nil
+}
+
+// initialize completes the initiaization of the cloudslam wrapper struct.
+func (svc *cloudslamWrapper) initialize() error {
+	var err error
+	svc.lastPose.Store(&initPose)
 	initJob := ""
-	wrapper.activeJob.Store(&initJob)
-	wrapper.lastPointCloudURL.Store(&initPCDURL)
+	svc.activeJob.Store(&initJob)
+	svc.lastPointCloudURL.Store(&initPCDURL)
 
 	// using this as a placeholder image. need to determine the right way to have the module use it
-	wrapper.defaultpcd, err = f.ReadFile(defaultPointCloudFilename)
+	svc.defaultpcd, err = f.ReadFile(defaultPointCloudFilename)
 	if err != nil {
-		return nil, err
+		return err
+	}
+	if svc.partID != "" {
+		svc.updatingMapName, svc.updatingMapVersion, err = svc.app.GetPackagesOnRobot(svc.cancelCtx, svc.partID)
+		if err != nil {
+			return err
+		}
 	}
 
 	// check if the robot has an active job
-	reqActives := &pbCloudSLAM.GetActiveMappingSessionsForRobotRequest{RobotId: wrapper.robotID}
-	resp, err := appClients.CSClient.GetActiveMappingSessionsForRobot(cancelCtx, reqActives)
+	reqActives := &pbCloudSLAM.GetActiveMappingSessionsForRobotRequest{RobotId: svc.robotID}
+	resp, err := svc.app.CSClient.GetActiveMappingSessionsForRobot(svc.cancelCtx, reqActives)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	wrapper.activeJob.Store(&resp.SessionId)
+	svc.activeJob.Store(&resp.SessionId)
 
-	wrapper.workers = utils.NewStoppableWorkers(wrapper.activeMappingSessionThread)
-
-	return wrapper, nil
+	svc.workers = utils.NewStoppableWorkers(svc.activeMappingSessionThread)
+	return nil
 }
 
 // activeMappingSessionThread polls app to retrieve the current map and pose of the cloudslam session.
@@ -275,7 +299,7 @@ func (svc *cloudslamWrapper) Close(ctx context.Context) error {
 func (svc *cloudslamWrapper) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
 	resp := map[string]interface{}{}
 	if name, ok := req[startJobKey]; ok {
-		jobID, err := svc.StartJob(svc.cancelCtx, name.(string))
+		jobID, isUpdating, err := svc.StartJob(svc.cancelCtx, name.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -283,7 +307,13 @@ func (svc *cloudslamWrapper) DoCommand(ctx context.Context, req map[string]inter
 		svc.lastPose.Store(&initPose)
 		svc.lastPointCloudURL.Store(&initPCDURL)
 
-		resp[startJobKey] = "Starting cloudslam session, the robot should appear in ~1 minute. Job ID: " + jobID
+		if isUpdating {
+			resp[updatingModeKey] = fmt.Sprintf("slam map found on machine, starting cloudslam in updating mode. Map "+
+				"Name = %v // Updating Version = %v", svc.updatingMapName, svc.updatingMapVersion)
+			resp[startJobKey] = "Starting cloudslam session, the robot should appear in ~1 minute. Job ID: " + jobID
+		} else {
+			resp[startJobKey] = "Starting cloudslam session, the robot should appear in ~1 minute. Job ID: " + jobID
+		}
 	}
 	if _, ok := req[stopJobKey]; ok {
 		packageURL, err := svc.StopJob(ctx)
@@ -321,7 +351,8 @@ func (svc *cloudslamWrapper) StopJob(ctx context.Context) (string, error) {
 }
 
 // StartJob starts a cloudslam job with the requested map name. Currently assumes a set of config parameters.
-func (svc *cloudslamWrapper) StartJob(ctx context.Context, mapName string) (string, error) {
+func (svc *cloudslamWrapper) StartJob(ctx context.Context, mapName string) (string, bool, error) {
+	updatingMode := false
 	starttime := timestamppb.New(time.Now())
 	interval := pbCloudSLAM.CaptureInterval{StartTime: starttime}
 	configParams, err := structpb.NewStruct(map[string]any{
@@ -334,17 +365,22 @@ func (svc *cloudslamWrapper) StartJob(ctx context.Context, mapName string) (stri
 		},
 	})
 	if err != nil {
-		return "", err
+		return "", updatingMode, err
 	}
 	req := &pbCloudSLAM.StartMappingSessionRequest{
 		SlamVersion: svc.slamVersion, ViamServerVersion: svc.viamVersion, MapName: mapName, OrganizationId: svc.organizationID,
 		LocationId: svc.locationID, RobotId: svc.robotID, CaptureInterval: &interval, Sensors: svc.sensorInfoToProto(), SlamConfig: configParams,
 	}
+	if svc.updatingMapName != "" {
+		req.MapName = svc.updatingMapName
+		req.ExistingMapVersion = svc.updatingMapVersion
+		updatingMode = true
+	}
 	resp, err := svc.app.CSClient.StartMappingSession(ctx, req)
 	if err != nil {
-		return "", err
+		return "", updatingMode, err
 	}
-	return resp.GetSessionId(), nil
+	return resp.GetSessionId(), updatingMode, nil
 }
 
 // sensorInfoToCSSensorInfo takes in a set of sensors from a SLAM algorithm's properties and adds each sensor's frequency to them
@@ -380,7 +416,7 @@ func (svc *cloudslamWrapper) sensorInfoToProto() []*pbCloudSLAM.SensorInfo {
 	return sensorsProto
 }
 
-// ParseSensorsForPackage parses the sensors list nto a list of sensor structs to add to the map package metadata.
+// ParseSensorsForPackage parses the sensors list not a list of sensor structs to add to the map package metadata.
 func (svc *cloudslamWrapper) ParseSensorsForPackage() ([]interface{}, error) {
 	sensorMetadata := []interface{}{}
 	for _, sensor := range svc.sensors {

--- a/cloudslam/cloudslam.go
+++ b/cloudslam/cloudslam.go
@@ -310,10 +310,9 @@ func (svc *cloudslamWrapper) DoCommand(ctx context.Context, req map[string]inter
 		if isUpdating {
 			resp[updatingModeKey] = fmt.Sprintf("slam map found on machine, starting cloudslam in updating mode. Map "+
 				"Name = %v // Updating Version = %v", svc.updatingMapName, svc.updatingMapVersion)
-			resp[startJobKey] = "Starting cloudslam session, the robot should appear in ~1 minute. Job ID: " + jobID
-		} else {
-			resp[startJobKey] = "Starting cloudslam session, the robot should appear in ~1 minute. Job ID: " + jobID
 		}
+		resp[startJobKey] = "Starting cloudslam session, the robot should appear in ~1 minute. Job ID: " + jobID
+
 	}
 	if _, ok := req[stopJobKey]; ok {
 		packageURL, err := svc.StopJob(ctx)

--- a/cloudslam/createpackage.go
+++ b/cloudslam/createpackage.go
@@ -24,11 +24,11 @@ const (
 	internalStateName = "internalState.pbstream"
 )
 
-// UploadPackage grabs the current pcd map and internal state of the cloud managed robot
-// and creates a package at the robots location using the CreatePackage API.
+// UploadPackage grabs the current pcd map and internal state of the cloud managed machine
+// and creates a package at the machines location using the CreatePackage API.
 func (svc *cloudslamWrapper) UploadPackage(ctx context.Context, mapName string) (string, error) {
 	if svc.partID == "" {
-		return "", errors.New("must set robot_part_id in config to use this feature")
+		return "", errors.New("must set machine_part_id in config to use this feature")
 	}
 	// grab the current time to mark the "version" of the slam map
 	packageVersion := strconv.FormatInt(time.Now().Unix(), 10)
@@ -303,7 +303,7 @@ func (svc *cloudslamWrapper) GetPackageMetadata(thumbnailFileID string) (*struct
 		"file_id":       thumbnailFileID,
 		"module":        "cartographer-module",
 		"moduleVersion": svc.slamVersion,
-		"robot_id":      svc.robotID,
+		"robot_id":      svc.machineID,
 		"location_id":   svc.locationID,
 		"sensors":       sensorMetadata,
 	})

--- a/cloudslam/createpackage.go
+++ b/cloudslam/createpackage.go
@@ -58,7 +58,7 @@ func (svc *cloudslamWrapper) UploadPackage(ctx context.Context, mapName string) 
 	return packageURL, nil
 }
 
-// uploadArchive creates a tar/archive of the SLAM map and uploads it to app using the package APIs
+// uploadArchive creates a tar/archive of the SLAM map and uploads it to app using the package APIs.
 func (svc *cloudslamWrapper) uploadArchive(ctx context.Context, files []SLAMFile, mapName, thumbnailFileID, packageVersion string) error {
 	myPackage, err := CreateArchive(files)
 	if err != nil {
@@ -106,7 +106,7 @@ func (svc *cloudslamWrapper) uploadArchive(ctx context.Context, files []SLAMFile
 	return nil
 }
 
-// sendPackageRequests sends the package to app
+// sendPackageRequests sends the package to app.
 func sendPackageRequests(ctx context.Context, stream pbPackage.PackageService_CreatePackageClient,
 	f *bytes.Buffer, packageInfo *pbPackage.PackageInfo,
 ) error {
@@ -145,7 +145,7 @@ func sendPackageRequests(ctx context.Context, stream pbPackage.PackageService_Cr
 	}
 }
 
-// getCreatePackageRequest creates a package request with a chunk of the package
+// getCreatePackageRequest creates a package request with a chunk of the package.
 func getCreatePackageRequest(ctx context.Context, f *bytes.Buffer) (*pbPackage.CreatePackageRequest, error) {
 	select {
 	case <-ctx.Done():
@@ -165,7 +165,7 @@ func getCreatePackageRequest(ctx context.Context, f *bytes.Buffer) (*pbPackage.C
 	}
 }
 
-// readNextFileChunk gets a chunk of data from a buffer
+// readNextFileChunk gets a chunk of data from a buffer.
 func readNextFileChunk(f *bytes.Buffer) ([]byte, error) {
 	byteArr := make([]byte, UploadChunkSize)
 	numBytesRead, err := f.Read(byteArr)
@@ -277,7 +277,7 @@ type SLAMFile struct {
 	name         string
 }
 
-// findPCD finds a pcd file in a list of slam files
+// findPCD finds a pcd file in a list of slam files.
 func findPCD(files []SLAMFile) ([]byte, error) {
 	for _, f := range files {
 		if f.slamFileType == PCDType {

--- a/cloudslam/thumbnail.go
+++ b/cloudslam/thumbnail.go
@@ -28,7 +28,7 @@ const (
 	robotMarkerRadius = 5    // radius of robot marker point
 )
 
-// createThumbnail creates a jpeg image of the pointcloud map that acts as a thumbnail preview
+// createThumbnail creates a jpeg image of the pointcloud map that acts as a thumbnail preview.
 func (svc *cloudslamWrapper) createThumbnail(ctx context.Context, files []SLAMFile, mapName, versionTimestamp string) (string, error) {
 	pcd, err := findPCD(files)
 	if err != nil {
@@ -48,7 +48,7 @@ func (svc *cloudslamWrapper) createThumbnail(ctx context.Context, files []SLAMFi
 	return thumbnailFileID, nil
 }
 
-// uploadJpeg uploads a jpeg thumbnail of a pointcloud used for a slam map package
+// uploadJpeg uploads a jpeg thumbnail of a pointcloud used for a slam map package.
 func (svc *cloudslamWrapper) uploadJpeg(
 	ctx context.Context,
 	content *bytes.Buffer,
@@ -101,7 +101,7 @@ func (svc *cloudslamWrapper) uploadJpeg(
 	return res.GetFileId(), nil
 }
 
-// pcdToJpeg converts a pointcloud data into a jpeg image
+// pcdToJpeg converts a pointcloud data into a jpeg image.
 func pcdToJpeg(pcd []byte) (*bytes.Buffer, error) {
 	ppRM := NewParallelProjectionOntoXYWithRobotMarker(nil)
 	pc, err := pointcloud.ReadPCD(bytes.NewBuffer(pcd))
@@ -343,7 +343,7 @@ func readNextFileUploadFileChunk(f *bytes.Buffer) (*pbDataSync.FileData, error) 
 	return &pbDataSync.FileData{Data: byteArr}, nil
 }
 
-// getNextFileUploadRequest gets the next chunk of a file upload for data sync
+// getNextFileUploadRequest gets the next chunk of a file upload for data sync.
 func getNextFileUploadRequest(ctx context.Context, f *bytes.Buffer) (*pbDataSync.FileUploadRequest, error) {
 	select {
 	case <-ctx.Done():
@@ -363,7 +363,7 @@ func getNextFileUploadRequest(ctx context.Context, f *bytes.Buffer) (*pbDataSync
 	}
 }
 
-// sendFIleUploadRequests sends a file upload to app in a series of chunks
+// sendFIleUploadRequests sends a file upload to app in a series of chunks.
 func sendFileUploadRequests(ctx context.Context, stream pbDataSync.DataSyncService_FileUploadClient, f *bytes.Buffer) error {
 	// Loop until there is no more content to be read from file.
 	for {

--- a/meta.json
+++ b/meta.json
@@ -1,6 +1,6 @@
 {
   "module_id": "viam:cloudslam-wrapper",
-  "visibility": "private",
+  "visibility": "public",
   "url": "https://github.com/viam-modules/cloudslam-wrapper",
   "description": "A SLAM service that lets users interact with cloudslam",
   "models": [


### PR DESCRIPTION
this pr adds the ability to use updating mode with the cloudslam module. It works by making a `Config` Request to app, then parsing the packages within the config until a `slam_map` package is found. This assumes that only one map package is configured on the robot, which is a perfectly valid assumption. The feature only works if a machine part ID is configured in on the service, which allows users a workaround to disable updating mode as an option for cloudslam, if they choose to. 

Using the Config API might not be the best choice, as it is the API that viam-servers use to read their own configs, but functionally it does what we want and is a part of the public API that location owners have permission to use. 

ticket: https://viam.atlassian.net/browse/RSDK-8438